### PR TITLE
[BDRK-2675] Extract spark dependencies to maven file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Order is important; the last matching pattern takes the most
+# precedence.
+# https://help.github.com/en/articles/about-code-owners
+* @basisai/developers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: java:maven
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "00:00"
+    open-pull-requests-limit: 5
+    allow:
+      - dependency-type: direct
+    rebase-strategy: disabled
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "00:00"
+    open-pull-requests-limit: 5
+    allow:
+      - dependency-type: direct
+    rebase-strategy: disabled

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,23 @@
+name: Build and test spark image
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened, synchronize]
+    paths:
+      - Dockerfile
+      - pom.xml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build image
+        uses: docker/build-push-action@v1.1.0
+        env:
+          DOCKER_BUILDKIT: 1
+        with:
+          repository: basisai/workload-standard
+          tag_with_ref: true
+          push: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,10 @@ RUN curl https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SP
 
 # Install 3rd party packages
 COPY pom.xml .
-RUN mvn dependency:copy-dependencies
+RUN mvn dependency:copy-dependencies && \
+    # Remove outdated guava library
+    rm jars/guava-14.0.1.jar && \
+    mvn dependency:purge-local-repository -DreResolve=false
 
 # Finalize the image for production use
 RUN echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,63 +1,38 @@
 FROM python:3.8.5-buster
 
-ARG SPARK_JARS=jars
-ARG IMG_PATH=kubernetes/dockerfiles
 ARG SPARK_VERSION=3.0.0
 ARG HADOOP_VERSION=3.2
+ARG JDK_VERSION=11
 
 ENV SPARK_HOME /opt/spark
-ENV JAVA_HOME /usr/lib/jvm/adoptopenjdk-11-hotspot-amd64
+ENV JAVA_HOME /usr/lib/jvm/java-${JDK_VERSION}-openjdk-amd64
 ENV PYTHONPATH ${SPARK_HOME}/python/lib/pyspark.zip:${SPARK_HOME}/python/lib/py4j-*.zip
 ENV PATH ${PATH}:${SPARK_HOME}/bin
 
-WORKDIR /
+WORKDIR ${SPARK_HOME}
 
-RUN \
-    # Add AdoptOpenJDK repository for Java 11
-    apt-get update && \
-    wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add - && \
-    apt-get install -y software-properties-common && \
-    add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ && \
-    # Install dependencies
-    apt-get update && \
-    apt-get install -y adoptopenjdk-11-hotspot python3-dev && \
-    # Install Spark
-    curl https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz -OLJ && \
-    tar -xzvf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz && \
-    cd spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} && \
-    mkdir -p ${SPARK_HOME}/python && \
-    set -ex && \
-    mkdir -p /opt/spark && \
-    mkdir -p /opt/spark/work-dir && \
-    touch /opt/spark/RELEASE && \
-    rm /bin/sh && \
-    ln -sv /bin/bash /bin/sh && \
-    echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su && \
+RUN apt-get update && apt-get install -y \
+    openjdk-${JDK_VERSION}-jre-headless \
+    maven \
+    python3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install spark and hadoop
+RUN curl https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz -OLJ && \
+    tar -xzvf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz --strip-components=1 && \
+    rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
+
+# Install 3rd party packages
+COPY pom.xml .
+RUN mvn dependency:copy-dependencies
+
+# Finalize the image for production use
+RUN echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su && \
+    # Only permit root access to members of group wheel
     chgrp root /etc/passwd && chmod ug+rw /etc/passwd && \
-    cp -r ${SPARK_JARS} /opt/spark/jars && \
-    cp -r bin /opt/spark/bin && \
-    cp -r sbin /opt/spark/sbin && \
-    cp -r ${IMG_PATH}/spark/entrypoint.sh /opt/ && \
-    cp -r examples /opt/spark/examples && \
-    cp -r data /opt/spark/data && \
-    cp -r python/lib ${SPARK_HOME}/python/lib && \
+    # Create an entrypoint file
+    cp kubernetes/dockerfiles/spark/entrypoint.sh /opt/ && \
     # Sed command to remove use of tini
-    sed -i -e 's/\/usr\/bin\/tini[^"]*//g' /opt/entrypoint.sh && \
-    # Remove extracted Spark
-    rm -rf /spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}
+    sed -i -e 's/\/usr\/bin\/tini[^"]*//g' /opt/entrypoint.sh
 
-RUN cd ${SPARK_HOME}/jars && \
-    # Install GCS connector
-    curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop3-latest.jar -OLJ && \
-    # Install Hadoop AWS integration
-    curl https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.2.1/hadoop-aws-3.2.1.jar -OLJ && \
-    # Update Guava
-    curl https://repo1.maven.org/maven2/com/google/guava/guava/29.0-jre/guava-29.0-jre.jar -OLJ && \
-    curl https://repo1.maven.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar -OLJ && \
-    rm guava-14.0.1.jar && \
-    # Install AWS SDK For Java
-    curl https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.848/aws-java-sdk-bundle-1.11.848.jar -OLJ
-
-WORKDIR /opt/spark/work-dir
-
-ENTRYPOINT [ "/opt/entrypoint.sh" ]
+ENTRYPOINT ["/opt/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ COPY pom.xml .
 RUN mvn dependency:copy-dependencies && \
     # Remove outdated guava library
     rm jars/guava-14.0.1.jar && \
-    mvn dependency:purge-local-repository -DreResolve=false
+    # Purge local maven cache
+    rm -rf /root/.m2
 
 # Finalize the image for production use
 RUN echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ WORKDIR ${SPARK_HOME}
 RUN apt-get update && apt-get install -y \
     openjdk-${JDK_VERSION}-jre-headless \
     maven \
-    python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install spark and hadoop

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,20 @@
 	</build>
 
 	<dependencies>
+		<!-- https://mvnrepository.com/artifact/org.apache.spark/spark-core -->
+		<dependency>
+			<groupId>org.apache.spark</groupId>
+			<artifactId>spark-core_2.12</artifactId>
+			<version>3.0.0</version>
+			<!-- Only adding spark here for version check -->
+			<exclusions>
+				<exclusion>
+					<groupId>*</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
 		<!-- https://mvnrepository.com/artifact/com.google.cloud.bigdataoss/gcs-connector -->
 		<dependency>
 			<groupId>com.google.cloud.bigdataoss</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,14 +22,29 @@
 		<dependency>
 			<groupId>com.google.cloud.bigdataoss</groupId>
 			<artifactId>gcs-connector</artifactId>
-			<version>hadoop3-2.1.4</version>
+			<version>hadoop3-1.9.18</version>
+			<!-- Can be removed after upgrading to hadoop 3.3.0 -->
+			<exclusions>
+				<exclusion>
+					<groupId>com.sun.jmx</groupId>
+					<artifactId>jmxri</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.sun.jdmk</groupId>
+					<artifactId>jmxtools</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>javax.jms</groupId>
+					<artifactId>jms</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-aws -->
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-aws</artifactId>
-			<version>3.2.1</version>
+			<version>3.2.0</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.google.guava/guava -->

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.basis-ai.bedrock</groupId>
+	<artifactId>workload-standard</artifactId>
+	<version>0.2.0</version>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<configuration>
+					<outputDirectory>${env.SPARK_HOME}/jars</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies>
+		<!-- https://mvnrepository.com/artifact/com.google.cloud.bigdataoss/gcs-connector -->
+		<dependency>
+			<groupId>com.google.cloud.bigdataoss</groupId>
+			<artifactId>gcs-connector</artifactId>
+			<version>hadoop3-2.1.4</version>
+		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-aws -->
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-aws</artifactId>
+			<version>3.2.1</version>
+		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>29.0-jre</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>com.basis-ai.bedrock</groupId>
 	<artifactId>workload-standard</artifactId>
-	<version>0.2.0</version>
+	<version>0.2.1</version>
 
 	<build>
 		<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
 				<configuration>
-					<outputDirectory>${env.SPARK_HOME}/jars</outputDirectory>
+					<outputDirectory>jars</outputDirectory>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
- Setup dependabot to scan pom.xml for dependency upgrades.
- Use maven to resolve transitive dependencies for gcs and s3 connectors.
- Also reduced image size from 1.1GB to 700MB.

Successful runs:
- GCP: https://bedrock.basis-ai.com/project/view/default/training/pipeline/view/churn-aws-9cad11d3/run/17
- AWS: https://bedrock.basis-ai.com/project/view/default/training/pipeline/view/churn-aws-9cad11d3/run/18

Tried to use multistage docker build for further space savings, but it only reduced the compressed size by a few MB (only removed the maven binary I think) so not really worth it.