### PR TITLE
Remove outdated jackson

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,10 @@ RUN curl https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SP
     tar -xzvf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz --strip-components=1 && \
     rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
 
+# Patch htrace-core4 to fix vulnerabilities
+RUN curl https://github.com/basisai/incubator-retired-htrace/releases/download/v4.1.0/htrace-core4-4.1.0-incubating.jar -OLJ && \
+    mv htrace-core4-4.1.0-incubating.jar jars/
+
 # Install 3rd party packages
 COPY pom.xml .
 RUN mvn dependency:copy-dependencies && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ COPY pom.xml .
 RUN mvn dependency:copy-dependencies && \
     # Remove outdated libraries
     rm -vf jars/guava-14.0.1.jar && \
+    rm -vf jars/jackson-core-asl-1.9.13.jar && \
+    rm -vf jars/jackson-mapper-asl-1.9.13.jar && \
     # Purge local maven cache
     rm -rf /root/.m2
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,13 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.basis-ai.bedrock</groupId>
 	<artifactId>workload-standard</artifactId>
-	<version>0.3.3</version>
+	<version>0.3.4</version>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
Based on my [code search](https://github.com/apache/spark/search?l=Maven+POM&q=codehaus++jackson), Jackson 1 was pulled in by spark for 2 reasons
1. Backwards compatibility with hadoop 2 (we are using hadoop 3 so no issues here)
2. To support spark’s custom hive client (if anyone is using apache hive, that could break)

Everywhere else, including apache hadoop and apache hive, jackson 1 was a banned import. We can consider submitting a patch to spark for a more permanent fix.

Tested on playground-production:
- https://bedrock.basis-ai.com/project/view/qiao/training/pipeline/view/churn-fork/run/10

Depends on:
- [x] https://github.com/basisai/incubator-retired-htrace/pull/1