### PR TITLE
Fix docker buildx push and output conflict

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,18 +39,29 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push
-        id: docker_build
+        if: ${{ github.event_name == 'pull_request' }}
         uses: docker/build-push-action@v2
         with:
           context: .
           file: ./Dockerfile
           # platforms: linux/amd64,linux/arm64,linux/386
-          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           outputs: type=docker,dest=/tmp/workload-standard-${{ github.sha }}.tar
+      - name: Build and push
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          # platforms: linux/amd64,linux/arm64,linux/386
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
       - name: Upload artifact
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Fix the error `buildx failed with: error: push and "docker" output can't be used together`.