### PR TITLE
Fix image-tag output when release new git tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,8 +12,11 @@ on:
 jobs:
   build:
     runs-on: [self-hosted, docker, integration]
+    env:
+      # list of Docker images to use as base name for tags
+      IMAGE_REPO: quay.io/basisai/workload-standard
     outputs:
-      image-tags: ${{ steps.docker_meta.outputs.version }}
+      image-tags: ${{ env.IMAGE_REPO }}:${{ steps.docker_meta.outputs.version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -21,7 +24,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v3
         with:
-          images: quay.io/basisai/workload-standard # list of Docker images to use as base name for tags
+          images: ${{ env.IMAGE_REPO }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: [self-hosted, docker, integration]
     outputs:
-      image-tags: ${{ steps.meta.outputs.version }}
+      image-tags: ${{ steps.docker_meta.outputs.version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: [self-hosted, docker, integration]
     outputs:
-      image-tags: ${{ fromJSON(steps.docker_meta.outputs.json).labels['org.opencontainers.image.version'] }}
+      image-tags: ${{ steps.meta.outputs.version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: [self-hosted, docker, integration]
     outputs:
-      image-tags: ${{ steps.docker_meta.outputs.tags }}
+      image-tags: ${{ fromJSON(steps.docker_meta.outputs.json).labels['org.opencontainers.image.version'] }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
When a new Git tag is released, Docker meta workflow generated 2 tags as below:

```
  {
    "tags": [
      "quay.io/basisai/workload-standard:v0.3.5",
      "quay.io/basisai/workload-standard:latest"
    ],
    "labels": {
      "org.opencontainers.image.title": "docker-workload",
      "org.opencontainers.image.description": "Docker images for machine learning workloads.",
      "org.opencontainers.image.url": "https://github.com/basisai/docker-workload",
      "org.opencontainers.image.source": "https://github.com/basisai/docker-workload",
      "org.opencontainers.image.version": "v0.3.5",
```

That caused the Trivy scan failed because of multiple targets defined:

```
Running trivy with options:  --format  template --template  @/contrib/sarif.tpl --exit-code  1 --ignore-unfixed --vuln-type  os,library --severity  CRITICAL --output  trivy-results-CRITICAL.sarif --no-progress  quay.io/basisai/workload-standard:v0.3.5
quay.io/basisai/workload-standard:latest
Global options:  
2021-12-31T04:27:13.357Z	ERROR	multiple targets cannot be specified
2021-12-31T04:27:13.357Z	FATAL	option error: option initialize error: arguments error
```

To get the correct image version for Trivy scan, we can use `${{ fromJSON(steps.docker_meta.outputs.json).labels['org.opencontainers.image.version'] }}` as [this reference](https://github.com/docker/metadata-action#json-output-object).